### PR TITLE
Add clear option to release method

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,13 +157,16 @@ class ChromePool {
   /**
    * call on a tab when your job on this tab is finished
    * @param {string} tabId
+   * @param {boolean} clear - navigate to about:blank after release
    */
-  async release(tabId) {
+  async release(tabId, clear = true) {
     let tab = this.tabs[tabId];
 
     // navigate this tab to blank to release this tab's resource
     // https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-navigate
-    await tab.protocol.Page.navigate({ url: 'about:blank' });
+    if (clear) {
+      await tab.protocol.Page.navigate({url: 'about:blank'});
+    }
     tab.free = true;
 
     // remove all listeners to fix MaxListenersExceededWarning: Possible EventEmitter memory leak detected


### PR DESCRIPTION
Some websites preload some extra data that can be used. So if you're using chrome-render module to crawl some particular website, disabling navigating to `about:blank` page can reduce page load time. It will increase resource usage, but if it's not a problem it could cause dramatic speedup of rendering.

By default it's set to true, that means the behavior remains the same. And if someone need to disable such feature - there will be an option for that.

In my case it decreased page load time by 30-50%.